### PR TITLE
Alias metadata

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -35,6 +35,7 @@ alias-help ()
     param '1: optional alias group'
     example '$ alias-help'
     example '$ alias-help git'
+    group 'lib'
 
     if [ -n "$1" ]; then
         cat $BASH_IT/aliases/enabled/$1.aliases.bash | metafor alias | sed "s/$/'/"
@@ -48,4 +49,27 @@ alias-help ()
             cat $f | metafor alias | sed "s/$/'/"
         done
     fi
+}
+
+bash-it-aliases ()
+{
+    about 'summarizes available bash_it aliases'
+    group 'lib'
+
+    typeset f
+    typeset enabled
+    printf "%-20s%-10s%s\n" 'Alias' 'Enabled?' 'Description'
+    for f in $BASH_IT/aliases/available/*.bash
+    do
+        if [ -e $BASH_IT/aliases/enabled/$(basename $f) ]; then
+            enabled='x'
+        else
+            enabled=' '
+        fi
+        printf "%-20s%-10s%s\n" "$(basename $f | cut -d'.' -f1)" "  [$enabled]" "$(cat $f | metafor about-aliases)"
+    done
+    printf '\n%s\n' 'to enable an alias group, do:'
+    printf '%s\n' '$ enable-alias  <alias group> -or- $ enable-alias all'
+    printf '\n%s\n' 'to disable an alias group, do:'
+    printf '%s\n' '$ disable-alias <alias group> -or- $ disable-alias all'
 }

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -28,3 +28,24 @@ function reload_completion() {
 function reload_plugins() {
   _load_bash_it_files "plugins"
 }
+
+alias-help ()
+{
+    about 'shows help for all aliases, or a specific alias group'
+    param '1: optional alias group'
+    example '$ alias-help'
+    example '$ alias-help git'
+
+    if [ -n "$1" ]; then
+        cat $BASH_IT/aliases/enabled/$1.aliases.bash | metafor alias | sed "s/$/'/"
+    else
+        typeset f
+        for f in $BASH_IT/aliases/enabled/*
+        do
+            typeset file=$(basename $f)
+            printf '\n\n%s:\n' "${file%%.*}"
+            # metafor() strips trailing quotes, restore them with sed..
+            cat $f | metafor alias | sed "s/$/'/"
+        done
+    fi
+}


### PR DESCRIPTION
Travis, thinking ahead here...

Expanding on what I've done with plugin metadata, the copy/paste approach to doing similar 'dynamic' metadata tricks with aliases, completions, and themes, would result in the following functions, all nearly identical:

bash-it-plugins
bash-it-aliases
bash-it-completions
bash-it-themes

enable-plugins
enable-aliases
enable-completions
enable-themes

disable-plugins
disable-aliases
disable-completions
disable-themes

plugins-help
aliases-help
completions-help
themes-help

That's alot of repetition, and not very DRY.

What do you think about having a top-level function, let's co-opt the existing 'bash-it()' function for this discussion... have 'bash-it()' take verb and noun parameters, with a grammar roughly like:

``` bash
$ bash-it 
               show
               enable
               disable
               help
                          aliases
                          completions
                          plugins
                          themes
                                        <optional type name>
```

Would this single-entry type of consolidation be a net help?
